### PR TITLE
chore: Fix gitignore, restore SECURITY_SUMMARY.md, add CONTRIBUTING.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,11 +57,8 @@ bandit-report.json
 # Generated test reports (regenerate with: pytest --cov)
 docs/testing/coverage-report.md
 
-# Generated security audit reports (contain vulnerability details + regenerable)
-docs/security/audit-*.md
-docs/security/vulnerabilities.md
-docs/security/remediation-roadmap.md
-docs/security/SECURITY_SUMMARY.md
+# Generated security audit reports (regenerate with: ./scripts/run_security_audit.sh --report)
+docs/security/audits/
 
 # Agent work summaries (temporary metadata)
 docs/**/ISSUE-*-SUMMARY.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,151 @@
+# Contributing to PelotonRacer
+
+Guidelines for human contributors and AI agents working on this codebase.
+
+## Development Workflow
+
+### Before You Start
+
+```bash
+pip install -r requirements.txt
+pip install -r requirements-security.txt
+pre-commit install
+```
+
+### Before Every Commit
+
+1. **Run the full test suite** and verify all tests pass:
+   ```bash
+   pytest tests/ -v --cov=src --cov-report=term-missing
+   ```
+2. **Run security tests** if you touched `src/api/` or `src/services/`:
+   ```bash
+   pytest tests/ -m security -v
+   ```
+3. Pre-commit hooks run automatically on `git commit` (secrets detection, bandit, formatting).
+
+### Before Every PR
+
+- All 307+ tests pass with 97%+ coverage
+- No new CRITICAL or HIGH security findings introduced
+- Run `./scripts/run_security_audit.sh` to verify
+
+## Code Conventions
+
+### Python
+
+- Dataclasses with `from_dict()`/`to_dict()` for models
+- Static methods for stateless analysis (`race_analyzer.py`)
+- `ThreadPoolExecutor` for parallel API calls
+- Environment variables via `.env` for credentials (never hardcode)
+
+### Security
+
+- **Thresholds:** Zero CRITICAL, <=2 HIGH findings (established in issue #18)
+- **No secrets in code or docs:** Use `.env` files, gitignored
+- **No vulnerability details in checked-in files:** Run `./scripts/run_security_audit.sh --report` to generate reports locally (output is gitignored in `docs/security/audits/`)
+- **Sanitize error messages:** No file paths, stack traces, or internal details in user-facing exceptions (CWE-209)
+- **Validate file paths:** All file operations must check against allowed directories
+
+#### Severity Response Timeframes
+
+| Severity | Examples | Remediation Target | Tracking |
+|----------|----------|---------------------|----------|
+| **CRITICAL** | Active exploitation, credential leak, auth bypass | Immediate -- fix within 24-48 hours | Dedicated issue, blocks release |
+| **HIGH** | Exploitable vulnerability, significant security flaw | Within current sprint (1-2 weeks) | Dedicated issue with acceptance criteria |
+| **MEDIUM** | Potential vulnerability, requires specific conditions | Next planned release | Track in backlog |
+| **LOW** | Minor improvement, best practice violation | Opportunistic | Track in backlog |
+
+#### Security Documentation Quality
+
+When writing security reports or audit documentation:
+
+- Use **CVSS scores** for vulnerability severity assessment
+- Apply **STRIDE** threat modeling (Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege)
+- Map findings to **OWASP Top 10** categories where applicable
+- Include **specific remediation steps** with code examples, not just descriptions of problems
+- Provide **effort estimates** and **priority ordering** for remediation work
+- Add **verification checklists** so fixes can be confirmed
+
+### Testing
+
+- Mark tests with `@pytest.mark.unit`, `@pytest.mark.integration`, or `@pytest.mark.security`
+- Use shared fixtures from `tests/conftest.py` (30+ available)
+- Test edge cases and error paths, not just happy paths
+- See [docs/testing/TESTING.md](docs/testing/TESTING.md) for the full testing guide
+
+## Documentation Standards
+
+When writing or updating documentation:
+
+- **Actionable content** -- include specific steps, commands, and effort estimates rather than vague guidance
+- **Consistent formatting** -- markdown with clear hierarchy, tables for structured data, code blocks with syntax highlighting
+- **Working internal links** -- use relative paths, validate cross-references
+- **No stale information** -- update test counts, coverage numbers, and tool versions when they change
+- **Executive summaries** -- lead with context for both technical and non-technical readers
+
+## Documentation Structure
+
+```
+docs/
+├── security/
+│   ├── README.md                # Security docs index
+│   ├── QUICK_REFERENCE.md       # One-page security tools reference
+│   ├── SECURITY_SETUP.md        # Security tool setup guide
+│   ├── SECURITY_PROCEDURES.md   # Incident response & procedures
+│   ├── SECURITY_SUMMARY.md      # Security monitoring setup summary
+│   └── audits/                  # Generated audit reports (gitignored)
+├── testing/
+│   ├── TESTING.md               # Complete testing guide
+│   └── coverage-report.md       # Coverage analysis (gitignored)
+└── plans/                       # Design docs and implementation plans
+```
+
+Root-level docs: `README.md`, `SECURITY.md` (policy), `SECURITY_QUICKSTART.md`, `CLAUDE.md` (AI agent context), this file.
+
+## Workflows by Role
+
+### Developers
+
+1. Run `./scripts/run_security_audit.sh --report` to generate a current security report
+2. Review generated reports in `docs/security/audits/`
+3. Check `docs/testing/coverage-report.md` for coverage gaps before adding tests
+4. Follow [docs/testing/TESTING.md](docs/testing/TESTING.md) for test patterns and fixtures
+
+### Security Reviewers
+
+Run `./scripts/run_security_audit.sh --report` to generate audit artifacts including STRIDE analysis, OWASP mapping, and remediation roadmap. Results are saved to a timestamped folder in `docs/security/audits/`.
+
+### QA
+
+- [docs/testing/TESTING.md](docs/testing/TESTING.md) -- complete testing guide with fixtures, markers, and best practices
+- `pytest tests/ -v --cov=src` -- run full suite with coverage
+- `pytest tests/ -m security -v` -- security tests only
+
+## Issue & PR Conventions
+
+- **Branch naming:** `fix/<issue>-<description>`, `feature/<description>`, `chore/<description>`
+- **Commit messages:** `type: description` (e.g., `security: Fix JWT validation`, `test: Add path traversal tests`, `docs: Update README`)
+- **Security issues** get their own tracking issues with acceptance criteria and test coverage -- not bundled into unrelated work
+- **New security findings** are tracked against the relevant release/change set, not always the parent infrastructure issue
+
+## For AI Agents
+
+In addition to everything above:
+
+- Read `CLAUDE.md` for project architecture and key commands
+- Run tests after every code change -- do not claim tests pass without running them
+- Do not include specific vulnerability details (CVE numbers, exploit steps, PoC code) in files that get committed
+- When creating issues, include acceptance criteria, estimated effort, and `How to Verify` section
+- Keep documentation current: if you change test counts, coverage, or tool versions, update all references
+
+## Key References
+
+| What | Where |
+|------|-------|
+| Testing guide | [docs/testing/TESTING.md](docs/testing/TESTING.md) |
+| Security docs | [docs/security/README.md](docs/security/README.md) |
+| Security quick ref | [docs/security/QUICK_REFERENCE.md](docs/security/QUICK_REFERENCE.md) |
+| Run security audit | `./scripts/run_security_audit.sh --report` |
+| Validate security setup | `bash scripts/validate_security_setup.sh` |
+| AI agent context | [CLAUDE.md](CLAUDE.md) |

--- a/docs/security/SECURITY_SUMMARY.md
+++ b/docs/security/SECURITY_SUMMARY.md
@@ -1,0 +1,338 @@
+# Security Monitoring Setup Summary
+
+**Issue:** #17 - Ongoing Security Monitoring & Maintenance
+**Date:** 2026-02-07
+**Status:** Complete
+
+## Overview
+
+Automated security monitoring has been successfully configured for the PelotonRacer project. This includes pre-commit hooks, GitHub Actions workflows, comprehensive documentation, and security tool configurations.
+
+## What Was Implemented
+
+### 1. Pre-commit Hooks (`.pre-commit-config.yaml`)
+
+Configured hooks that run automatically before each commit:
+
+- **detect-secrets** (v1.4.0) - Prevents credential commits
+- **bandit** (v1.7.5) - Python security linting
+- **Pre-commit hooks** (v4.5.0) - Common checks:
+  - YAML/JSON validation
+  - Large file detection (>1MB)
+  - Merge conflict detection
+  - Private key detection
+  - Trailing whitespace/EOF fixes
+- **pytest-fast** - Quick test execution (optional)
+
+**Location:** `.pre-commit-config.yaml`
+
+### 2. GitHub Actions Workflow (`.github/workflows/security-scan.yml`)
+
+Automated security scanning that runs:
+- On every pull request to main/develop
+- On every push to main
+- Weekly on Sundays at midnight UTC
+- Manual trigger available
+
+**Jobs:**
+
+1. **Dependency Scan**
+   - pip-audit for CVE detection
+
+2. **Security Linting**
+   - Bandit security analysis
+   - JSON report generation
+   - Artifact upload (30-day retention)
+
+3. **Secrets Detection**
+   - Full repository scan with detect-secrets
+   - Uses baseline for known false positives
+
+4. **Security Report**
+   - Aggregates all job results
+   - Posts summary to GitHub Actions
+
+**Location:** `.github/workflows/security-scan.yml`
+
+### 3. Security Documentation
+
+Three comprehensive guides created:
+
+#### a. Security Procedures (`SECURITY_PROCEDURES.md`)
+- How to report vulnerabilities
+- Security review checklist for PRs
+- Incident response procedures
+- Security monitoring schedule
+- Security best practices
+- Contact information
+
+**Location:** `docs/security/SECURITY_PROCEDURES.md`
+
+#### b. Security Setup Guide (`SECURITY_SETUP.md`)
+- Installation instructions
+- Tool usage examples
+- Troubleshooting guide
+- Common fixes for security issues
+- Best practices for daily use
+
+**Location:** `docs/security/SECURITY_SETUP.md`
+
+#### c. Security README (`README.md`)
+- Overview of all security documentation
+- Quick reference tables
+- File structure
+- Getting help resources
+
+**Location:** `docs/security/README.md`
+
+### 4. Security Requirements (`requirements-security.txt`)
+
+All security tools with pinned versions:
+
+```
+pre-commit>=3.6.0
+detect-secrets>=1.4.0
+bandit[toml]>=1.7.5
+pip-audit>=2.6.0
+```
+
+**Location:** `requirements-security.txt`
+
+### 5. Secrets Baseline (`.secrets.baseline`)
+
+Initialized detect-secrets baseline with all standard plugins:
+- AWS/Azure/GCP key detection
+- JWT token detection
+- Private key detection
+- High entropy string detection
+- And 20+ more secret types
+
+**Location:** `.secrets.baseline`
+
+### 6. Configuration Files
+
+#### a. Pylint Configuration (`.pylintrc`)
+- Python linting configuration
+- Security checks enabled
+- Reasonable defaults for the project
+- Compatible with Black formatting
+
+**Location:** `.pylintrc`
+
+#### b. Updated .gitignore
+Added security-related entries:
+```
+# Security
+.secrets.baseline
+security-reports/
+bandit-report.json
+.pylintrc
+```
+
+**Location:** `.gitignore`
+
+## Files Created/Modified
+
+### New Files (9)
+1. `.pre-commit-config.yaml` - Pre-commit hooks configuration
+2. `.github/workflows/security-scan.yml` - GitHub Actions workflow
+3. `docs/security/SECURITY_PROCEDURES.md` - Security procedures
+4. `docs/security/SECURITY_SETUP.md` - Setup guide
+5. `docs/security/README.md` - Security docs index
+6. `docs/security/SECURITY_SUMMARY.md` - This file
+7. `requirements-security.txt` - Security tool dependencies
+8. `.secrets.baseline` - Secrets detection baseline
+9. `.pylintrc` - Pylint configuration
+
+### Modified Files (1)
+1. `.gitignore` - Added security entries
+
+## How to Use
+
+### Initial Setup
+
+```bash
+# 1. Install security tools
+pip install -r requirements-security.txt
+
+# 2. Install pre-commit hooks
+pre-commit install
+
+# 3. Test the setup
+pre-commit run --all-files
+```
+
+### Daily Usage
+
+Pre-commit hooks run automatically:
+```bash
+git add .
+git commit -m "Your changes"
+# Hooks run automatically before commit
+```
+
+### Manual Security Scans
+
+```bash
+# Scan for secrets
+detect-secrets scan
+
+# Security linting
+bandit -r src/ -ll
+
+# Check dependencies
+pip-audit
+
+# Run all pre-commit hooks
+pre-commit run --all-files
+```
+
+### GitHub Actions
+
+- Runs automatically on PRs
+- View results in "Actions" tab
+- Can be triggered manually via GitHub UI
+
+## Security Monitoring Schedule
+
+| Frequency | Activity | How |
+|-----------|----------|-----|
+| **Every Commit** | Pre-commit hooks | Automatic |
+| **Every PR** | GitHub Actions scan | Automatic |
+| **Weekly** | Dependency vulnerability scan | Automatic (Sundays) |
+| **Monthly** | Manual security review | Manual |
+| **Quarterly** | Comprehensive audit | Manual |
+
+## Testing & Validation
+
+### Pre-commit Hooks
+- ✅ Configuration validated
+- ✅ All hooks properly defined
+- ✅ Compatible with project structure
+- ✅ Ready for installation
+
+### GitHub Actions
+- ✅ Valid YAML syntax
+- ✅ All jobs properly configured
+- ✅ Permissions set appropriately
+- ✅ Schedule configured correctly
+- ✅ Ready to run on next PR
+
+### Documentation
+- ✅ Comprehensive setup guide
+- ✅ Security procedures documented
+- ✅ Troubleshooting included
+- ✅ Best practices outlined
+- ✅ Quick reference available
+
+## Acceptance Criteria
+
+All criteria met:
+
+- ✅ Pre-commit hooks configured and tested
+- ✅ GitHub Action for security scanning working
+- ✅ Security procedures documented
+- ✅ Secrets detection baseline created
+- ✅ All security tools installable and runnable
+- ✅ Documentation for using security tools
+
+## Next Steps
+
+### For Developers
+
+1. **Install tools**: Run `pip install -r requirements-security.txt`
+2. **Set up hooks**: Run `pre-commit install`
+3. **Read docs**: Review `docs/security/SECURITY_SETUP.md`
+4. **Test**: Run `pre-commit run --all-files`
+
+### For Maintainers
+
+1. **Review workflow**: Check GitHub Actions after first PR
+2. **Update contacts**: Add contact info to `SECURITY_PROCEDURES.md`
+3. **Set schedule**: Ensure calendar reminders for manual reviews
+4. **Train team**: Share security documentation with contributors
+
+### Ongoing Maintenance
+
+1. **Weekly**: Review GitHub Actions results
+2. **Monthly**: Manual security review, update dependencies
+3. **Quarterly**: Update security tools, review procedures
+4. **As needed**: Respond to security findings, update baseline
+
+## Security Tools Reference
+
+### Secrets Detection
+```bash
+# Scan for secrets
+detect-secrets scan
+
+# Update baseline
+detect-secrets scan > .secrets.baseline
+
+# Audit findings
+detect-secrets audit .secrets.baseline
+```
+
+### Security Linting
+```bash
+# Basic scan
+bandit -r src/
+
+# Only medium/high severity
+bandit -r src/ -ll
+
+# JSON report
+bandit -r src/ -f json -o bandit-report.json
+```
+
+### Dependency Scanning
+```bash
+# Check for vulnerabilities
+pip-audit
+
+# Detailed output
+pip-audit --desc
+```
+
+## Resources
+
+### Documentation
+- [Security Setup Guide](./SECURITY_SETUP.md)
+- [Security Procedures](./SECURITY_PROCEDURES.md)
+- [Security README](./README.md)
+
+### External Resources
+- [Pre-commit](https://pre-commit.com/)
+- [Bandit](https://bandit.readthedocs.io/)
+- [detect-secrets](https://github.com/Yelp/detect-secrets)
+- [pip-audit](https://github.com/pypa/pip-audit)
+- [OWASP Top 10](https://owasp.org/www-project-top-ten/)
+
+## Support
+
+For questions or issues:
+1. Check documentation in `docs/security/`
+2. Review troubleshooting in `SECURITY_SETUP.md`
+3. Contact project maintainers
+4. Report security issues privately
+
+## Version
+
+**Version:** 1.1
+**Date:** 2026-02-08
+**Author:** Claude Code
+**Next Review:** 2026-05-07
+
+---
+
+## Summary
+
+PelotonRacer now has comprehensive automated security monitoring including:
+
+- **Pre-commit hooks** preventing security issues before they're committed
+- **GitHub Actions** providing continuous security scanning
+- **Documentation** guiding developers on security best practices
+- **Tools** for manual security audits and dependency scanning
+- **Procedures** for incident response and vulnerability reporting
+
+The security infrastructure is production-ready and follows industry best practices for Python projects.


### PR DESCRIPTION
## Summary

- Fix `.gitignore` to stop ignoring `docs/security/SECURITY_SUMMARY.md` and properly ignore `docs/security/audits/` directory
- Restore `SECURITY_SUMMARY.md` that was lost due to old gitignore rules
- Add `CONTRIBUTING.md` consolidating development practices, security guidelines, and conventions from `docs/ISSUE-21-SUMMARY.md` for both human contributors and AI agents

## Details

**CONTRIBUTING.md** includes:
- Development workflow (setup, pre-commit, pre-PR checklists)
- Code conventions (Python, security, testing)
- Security severity response timeframes (CRITICAL: 24-48h, HIGH: 1-2 weeks, etc.)
- Security documentation quality standards (CVSS, STRIDE, OWASP)
- Role-based workflows (developers, security reviewers, QA)
- Issue/PR conventions and documentation structure

## Test plan
- [ ] Verify `docs/security/SECURITY_SUMMARY.md` appears in tracked files
- [ ] Verify `docs/security/audits/` is gitignored
- [ ] Review CONTRIBUTING.md for accuracy and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)
