### PR TITLE
fix: remediate 5 HIGH security findings from Feb 2026 audit

### DIFF
--- a/scripts/run_security_audit.sh
+++ b/scripts/run_security_audit.sh
@@ -164,7 +164,15 @@ echo -e "${BOLD}[4/5] Running secrets scan...${NC}"
 SECRETS_AVAILABLE=true
 if command -v detect-secrets &> /dev/null; then
     set +e
-    detect-secrets scan --all-files 2>&1 | tee "${AUDIT_DIR}/secrets-scan.json"
+    detect-secrets scan \
+        --all-files \
+        --exclude-files '^\.venv/' \
+        --exclude-files '^htmlcov/' \
+        --exclude-files '^\.pytest_cache/' \
+        --exclude-files '^docs/security/audits/' \
+        --exclude-files '^data/' \
+        --exclude-files '^\.secrets\.baseline$' \
+        2>&1 | tee "${AUDIT_DIR}/secrets-scan.json"
     set -e
     echo -e "${GREEN}  detect-secrets results saved${NC}"
 else

--- a/src/api/peloton_client.py
+++ b/src/api/peloton_client.py
@@ -180,8 +180,8 @@ class PelotonClient:
             response = self.session.get(endpoint)
             response.raise_for_status()
             return response.json()
-        except Exception as e:
-            print(f"Failed to get user profile: {e}")
+        except Exception:
+            print("Failed to get user profile")
             return None
     
     def get_workouts(self, limit: int = 100, page: int = 0, fitness_discipline: str = None) -> List[Dict]:
@@ -214,8 +214,8 @@ class PelotonClient:
             
             data = response.json()
             return data.get("data", [])
-        except Exception as e:
-            print(f"Failed to get workouts: {e}")
+        except Exception:
+            print("Failed to get workouts")
             return []
     
     def get_all_workouts(self, max_workouts: int = None, fitness_discipline: str = "cycling") -> List[Dict]:
@@ -270,8 +270,8 @@ class PelotonClient:
             response.raise_for_status()
             
             return response.json()
-        except Exception as e:
-            print(f"Failed to get workout performance for {workout_id}: {e}")
+        except Exception:
+            print("Failed to get workout performance")
             return None
     
     def get_followers(self) -> List[Dict]:
@@ -293,8 +293,8 @@ class PelotonClient:
             
             data = response.json()
             return data.get("data", [])
-        except Exception as e:
-            print(f"Failed to get followers: {e}")
+        except Exception:
+            print("Failed to get followers")
             return []
     
     def get_user_workouts(self, user_id: str, limit: int = 100, page: int = 0, fitness_discipline: str = None) -> List[Dict]:
@@ -325,8 +325,8 @@ class PelotonClient:
             
             data = response.json()
             return data.get("data", [])
-        except Exception as e:
-            print(f"Failed to get workouts for user {user_id}: {e}")
+        except Exception:
+            print("Failed to get user workouts")
             return []
     
     def get_all_user_workouts(self, user_id: str, max_workouts: int = None, fitness_discipline: str = "cycling") -> List[Dict]:

--- a/src/services/data_manager.py
+++ b/src/services/data_manager.py
@@ -157,8 +157,8 @@ class DataManager:
             with open(self.user_profile_file, 'r') as f:
                 data = json.load(f)
                 return User(**data)
-        except Exception as e:
-            print(f"Error loading user profile: {e}")
+        except Exception:
+            print("Error loading user profile")
             return None
     
     def save_workouts(self, workouts: List[Workout], merge: bool = False) -> None:
@@ -202,8 +202,8 @@ class DataManager:
                 if valid_only:
                     workouts = [w for w in workouts if self.is_valid_ride(w.ride_info)]
                 return workouts
-        except Exception as e:
-            print(f"Error loading workouts: {e}")
+        except Exception:
+            print("Error loading workouts")
             return []
     
     def save_followers(self, followers: List[User]) -> None:
@@ -221,8 +221,8 @@ class DataManager:
             with open(self.followers_file, 'r') as f:
                 data = json.load(f)
                 return [User(**f) for f in data]
-        except Exception as e:
-            print(f"Error loading followers: {e}")
+        except Exception:
+            print("Error loading followers")
             return []
     
     def save_follower_workouts(self, workouts_by_user: Dict[str, List[Workout]], merge: bool = False) -> None:
@@ -276,8 +276,8 @@ class DataManager:
                     if workout_objs:  # Only include users with matching workouts
                         result[user_id] = workout_objs
                 return result
-        except Exception as e:
-            print(f"Error loading follower workouts: {e}")
+        except Exception:
+            print("Error loading follower workouts")
             return {}
     
     def clear_all_data(self) -> None:

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -620,13 +620,12 @@ def test_error_message_does_not_expose_full_paths(data_manager_with_temp_dir, ca
     # Capture printed output
     captured = capsys.readouterr()
 
-    # VULNERABILITY CHECK: Error messages should NOT expose full file paths
-    # Currently, the code prints "Error loading user profile: {e}"
-    # This might expose the exception which could contain file paths
+    # VULNERABILITY CHECK: Error messages should NOT expose internal details
+    # Messages must be generic without file paths, stack traces, or exception details
     if captured.out:
-        # Verify error message doesn't contain absolute paths
-        # This is a basic check - in production, errors should be logged securely
-        assert "Error loading user profile:" in captured.out or captured.out == ""
+        assert "Error loading user profile" in captured.out
+        # Ensure no sensitive information is leaked after the generic message
+        assert str(manager.user_profile_file) not in captured.out
 
 
 @pytest.mark.unit
@@ -643,7 +642,8 @@ def test_invalid_json_handling_workouts(data_manager_with_temp_dir, capsys):
 
     # Verify error was printed
     captured = capsys.readouterr()
-    assert "Error loading workouts:" in captured.out
+    assert "Error loading workouts" in captured.out
+    assert str(manager.workouts_file) not in captured.out
 
 
 @pytest.mark.unit
@@ -660,7 +660,8 @@ def test_invalid_json_handling_followers(data_manager_with_temp_dir, capsys):
 
     # Verify error was printed
     captured = capsys.readouterr()
-    assert "Error loading followers:" in captured.out
+    assert "Error loading followers" in captured.out
+    assert str(manager.followers_file) not in captured.out
 
 
 @pytest.mark.unit
@@ -677,7 +678,8 @@ def test_invalid_json_handling_follower_workouts(data_manager_with_temp_dir, cap
 
     # Verify error was printed
     captured = capsys.readouterr()
-    assert "Error loading follower workouts:" in captured.out
+    assert "Error loading follower workouts" in captured.out
+    assert str(manager.follower_workouts_file) not in captured.out
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Upgrade pip 24.2 → 26.0.1 and protobuf 6.33.4 → 6.33.5 to resolve 3 dependency CVEs
- Sanitize 9 exception handlers across `peloton_client.py` (5) and `data_manager.py` (4) to prevent sensitive information disclosure (CWE-209)
- Fix `detect-secrets` scan scope to exclude `.venv/`, `htmlcov/`, `.pytest_cache/`, old audit reports, and `data/` — reducing false positives from 5,126 to 11

## Verification
- Security audit: **0 CRITICAL, 0 HIGH** (down from 5 HIGH)
- All **307 tests pass** with 97% coverage
- 42 security-marked tests pass

## Test plan
- [x] `pytest tests/ -v --cov=src` — 307 passed
- [x] `pytest tests/ -m security -v` — 42 passed
- [x] `./scripts/run_security_audit.sh --report` — 0 CRITICAL, 0 HIGH
- [x] `pip-audit` — 0 dependency vulnerabilities

Fixes #25
Closes #18
Closes #17
Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)