### PR TITLE
fix: add *.pem and *.key patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ docs/security/audits/
 # Agent work summaries (temporary metadata)
 docs/**/ISSUE-*-SUMMARY.md
 docs/**/*-SUMMARY.md
+
+# Security patterns (auto-added)
+*.pem
+*.key


### PR DESCRIPTION
## Summary

- Adds `*.pem` and `*.key` to `.gitignore` to prevent private keys and certificate files from being accidentally committed to the repository
- Identified by the `/agent:security --quick` config scanner

## Test plan

- [ ] Verify `.gitignore` contains `*.pem` and `*.key` entries
- [ ] Confirm no existing `.pem` or `.key` files are tracked in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)