### PR TITLE
chore: gitignore planning product assessments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ data/
 .vscode/
 .idea/
 .claude/
+
+# Planning artifacts
+.planning/assessments/product/
 *.swp
 *.swo
 *~


### PR DESCRIPTION
## Summary
- Adds `.planning/assessments/product/` to `.gitignore` to exclude generated product health assessment reports from version control

## Test plan
- [x] Verify `.planning/assessments/product/` files no longer appear in `git status`
- [x] Verify other `.planning/` paths remain trackable

🤖 Generated with [Claude Code](https://claude.com/claude-code)